### PR TITLE
Outlines: add json_schema and max_length

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -143,18 +143,20 @@ OutlinesFramework:
   - task: "multilabel_classification"
     n_runs: 10
     init_kwargs:
-      prompt: "Classify the following text: {text}"
+      prompt: "Classify the following text: {text}.\nRespond in the following json schema: {json_schema}:\n"
       llm_model: "unsloth/llama-3-8b-Instruct-bnb-4bit"
       llm_model_family: "transformers"
       retries: 0 # Oulines transformers has no retry parameter
       source_data_pickle_path: "data/multilabel_classification.pkl"
+      max_length: 4096
       # sample_rows: 2
   - task: "synthetic_data_generation"
     n_runs: 100
     init_kwargs:
-      prompt: "Generate a random person's information. The name must be chosen at random. Make it something you wouldn't normally choose."
+      prompt: "Generate a random person's information. The name must be chosen at random. Make it something you wouldn't normally choose.\nRespond in the following json schema: {json_schema}:\n"
       llm_model: "unsloth/llama-3-8b-Instruct-bnb-4bit"
       llm_model_family: "transformers"
+      max_length: 4096
 
 LMFormatEnforcerFramework:
   - task: "multilabel_classification"

--- a/frameworks/outlines_framework.py
+++ b/frameworks/outlines_framework.py
@@ -8,6 +8,7 @@ from frameworks.base import BaseFramework, experiment
 class OutlinesFramework(BaseFramework):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.max_length = kwargs.get("max_length", 4096)
 
         # TODO: Handle openai model
         if self.llm_model_family == "transformers":
@@ -26,7 +27,13 @@ class OutlinesFramework(BaseFramework):
     ) -> tuple[list[Any], float, dict, list[list[float]]]:
         @experiment(n_runs=n_runs, expected_response=expected_response, task=task)
         def run_experiment(inputs):
-            response = self.outline_generator(self.prompt.format(**inputs))
+            response = self.outline_generator(
+                self.prompt.format(
+                    json_schema=self.response_model.model_json_schema(),
+                    **inputs,
+                ),
+                max_tokens=self.max_length,
+            )
             return response
 
         predictions, percent_successful, metrics, latencies = run_experiment(inputs)


### PR DESCRIPTION
Following LMFormatEnforcer, add for Outlines:

- `json_schema` to prompts
- `max_length` to model settings

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for `json_schema` in prompts and `max_length` in model settings within the Outlines framework to enhance response formatting and control token limits.

New Features:
- Introduce a `json_schema` parameter to prompts in the Outlines framework to enforce response formatting.
- Add a `max_length` parameter to model settings in the Outlines framework to limit the number of tokens in responses.

Enhancements:
- Update the prompt format in configuration to include the `json_schema` for structured responses.

<!-- Generated by sourcery-ai[bot]: end summary -->